### PR TITLE
🧹 Remove OperationEnum prefix stripping workarounds

### DIFF
--- a/components/policies.test.tsx
+++ b/components/policies.test.tsx
@@ -75,7 +75,7 @@ describe('Policies Component', () => {
       service: 'auth',
       resource_name: 'users',
       description: 'Read users',
-      operation: 'OperationEnum.READ',
+      operation: 'READ',
       created_at: '2025-01-01T00:00:00Z',
       updated_at: '2025-01-01T00:00:00Z',
     },
@@ -84,14 +84,14 @@ describe('Policies Component', () => {
       service: 'auth',
       resource_name: 'users',
       description: 'Create users',
-      operation: 'OperationEnum.CREATE',
+      operation: 'CREATE',
     },
     {
       id: 3,
       service: 'guardian',
       resource_name: 'roles',
       description: 'List roles',
-      operation: 'OperationEnum.LIST',
+      operation: 'LIST',
     },
   ];
 

--- a/components/policies.tsx
+++ b/components/policies.tsx
@@ -134,9 +134,8 @@ function getOperationIcon(operation: string, dictionary: PoliciesDictionary) {
     return { icon: null, label: "Unknown" };
   }
   
-  const cleanOperation = operation.replace(/^OperationEnum\./, "");
   const OPERATION_ICONS = getOperationIcons(dictionary);
-  const iconConfig = OPERATION_ICONS[cleanOperation as keyof typeof OPERATION_ICONS];
+  const iconConfig = OPERATION_ICONS[operation as keyof typeof OPERATION_ICONS];
   
   if (iconConfig) {
     const Icon = iconConfig.icon;
@@ -176,10 +175,8 @@ function groupPermissions(permissions: Permission[]) {
   // Trie les permissions dans chaque groupe
   Object.values(groups).forEach(group => {
     group.perms.sort((a, b) => {
-      const opA = a.operation.replace(/^OperationEnum\./, '');
-      const opB = b.operation.replace(/^OperationEnum\./, '');
-      const orderA = operationOrder[opA] || 999;
-      const orderB = operationOrder[opB] || 999;
+      const orderA = operationOrder[a.operation] || 999;
+      const orderB = operationOrder[b.operation] || 999;
       return orderA - orderB;
     });
   });
@@ -211,10 +208,8 @@ function groupAvailablePermissions(perms: Permission[]) {
   // Trie les permissions dans chaque groupe
   Object.values(groups).forEach(group => {
     group.perms.sort((a, b) => {
-      const opA = a.operation.replace(/^OperationEnum\./, '');
-      const opB = b.operation.replace(/^OperationEnum\./, '');
-      const orderA = operationOrder[opA] || 999;
-      const orderB = operationOrder[opB] || 999;
+      const orderA = operationOrder[a.operation] || 999;
+      const orderB = operationOrder[b.operation] || 999;
       return orderA - orderB;
     });
   });

--- a/lib/hooks/usePermissions.ts
+++ b/lib/hooks/usePermissions.ts
@@ -68,12 +68,8 @@ export function usePermissions(): UsePermissionsReturn {
           const service = perm.service || '';
           const resource = perm.resource_name || perm.resource || '';
           
-          // Fonction helper pour nettoyer les opérations (enlever "OperationEnum." si présent)
           // Les opérations Guardian sont en MAJUSCULES (READ, CREATE, UPDATE, DELETE, LIST)
-          const cleanOperation = (op: string): string => {
-            const cleaned = op.includes('.') ? op.split('.').pop() || op : op;
-            return cleaned.toUpperCase();
-          };
+          const normalizeOperation = (op: string): string => op.toUpperCase();
           
           // Si operations est un tableau, créer une permission par opération
           if (Array.isArray(perm.operations)) {
@@ -81,7 +77,7 @@ export function usePermissions(): UsePermissionsReturn {
               normalizedPerms.push({
                 service,
                 resource,
-                action: cleanOperation(operation),
+                action: normalizeOperation(operation),
               });
             }
           } else if (perm.operation) {
@@ -89,14 +85,14 @@ export function usePermissions(): UsePermissionsReturn {
             normalizedPerms.push({
               service,
               resource,
-              action: cleanOperation(perm.operation),
+              action: normalizeOperation(perm.operation),
             });
           } else if (perm.action) {
             // Ou action si présent
             normalizedPerms.push({
               service,
               resource,
-              action: cleanOperation(perm.action),
+              action: normalizeOperation(perm.action),
             });
           }
         }


### PR DESCRIPTION
## 📋 Summary

Removes workarounds that were stripping `OperationEnum.` prefix from operation values. The backend now returns clean enum values directly.

## 🔧 Changes

### lib/hooks/usePermissions.ts
- ❌ Removed `cleanOperation` helper function that stripped `OperationEnum.` prefix
- ✅ Now uses operation values directly with simple `toUpperCase()` normalization

### components/policies.tsx
- ❌ Removed `.replace(/^OperationEnum\./)` in `getOperationIcon` function
- ❌ Removed prefix stripping in 2 sorting functions
- ✅ Operations now used directly without preprocessing

### components/policies.test.tsx
- ✅ Updated mock data to match new backend format (`'READ'` instead of `'OperationEnum.READ'`)

## ✅ Verification

- ✅ All tests pass (25/25 in policies.test.tsx)
- ✅ Build succeeds without errors
- ✅ No more references to `OperationEnum.` prefix in codebase
- ✅ Cleaner, simpler code

## 📊 Impact

**Before:**
```typescript
const cleanOperation = (op: string): string => {
  const cleaned = op.includes('.') ? op.split('.').pop() || op : op;
  return cleaned.toUpperCase();
};
```

**After:**
```typescript
const normalizeOperation = (op: string): string => op.toUpperCase();
```

**Simplification:** 3 lines → 1 line per usage

## 🔗 Prerequisites

✅ Backend fix deployed (returns clean enum values)

## 🔗 Closes

Closes #28

---

**Ready for review** 🚀