### PR TITLE
feat: add PageBreadcrumb component with i18n support

### DIFF
--- a/app/home/admin/page.tsx
+++ b/app/home/admin/page.tsx
@@ -1,13 +1,7 @@
 import React from "react";
 import { getDictionary } from "@/lib/utils/dictionaries";
 import { getUserLanguage } from "@/lib/utils/locale";
-import {
-  Breadcrumb,
-  BreadcrumbList,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import PageBreadcrumb from "@/components/shared/PageBreadcrumb";
 import { AdminCards } from "@/components/cards/AdminCards";
 
 
@@ -17,19 +11,10 @@ export default async function AdminPage() {
     
   return (
     <div>
-      <div className="flex justify-center mb-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <span>Administration</span>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </div>
+      <PageBreadcrumb
+        pathname="/home/admin"
+        dictionary={dictionary.breadcrumb}
+      />
       <AdminCards dictionary={dictionary.admin_page} />
     </div>
   );

--- a/app/home/admin/roles/page.tsx
+++ b/app/home/admin/roles/page.tsx
@@ -1,12 +1,6 @@
 import Roles from "@/components/pages/RolesV2";
 import Policies from "@/components/pages/PoliciesV2";
-import {
-  Breadcrumb,
-  BreadcrumbList,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import PageBreadcrumb from "@/components/shared/PageBreadcrumb";
 import { getDictionary } from "@/lib/utils/dictionaries";
 import { getUserLanguage } from "@/lib/utils/locale";
 
@@ -16,23 +10,14 @@ export default async function RolesAdminPage() {
   
   return (
     <div className="p-6 space-y-10">
-      <div className="flex justify-center mb-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home/admin">Administration</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <span>{dictionary.roles.page_title}</span>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </div>
+      <PageBreadcrumb
+        pathname="/home/admin/roles"
+        dictionary={dictionary.breadcrumb}
+        siblings={[
+          { label: dictionary.breadcrumb.users, href: "/home/admin/users" },
+          { label: dictionary.breadcrumb.roles, href: "/home/admin/roles" },
+        ]}
+      />
       <Roles dictionary={{ ...dictionary.roles, errors: dictionary.errors }} />
       <Policies dictionary={{ ...dictionary.policies, errors: dictionary.errors }} />
     </div>

--- a/app/home/admin/users/page.tsx
+++ b/app/home/admin/users/page.tsx
@@ -1,10 +1,4 @@
-import {
-  Breadcrumb,
-  BreadcrumbList,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import PageBreadcrumb from "@/components/shared/PageBreadcrumb";
 import UsersV2 from "@/components/pages/UsersV2";
 import { getDictionary } from "@/lib/utils/dictionaries";
 import { getUserLanguage } from "@/lib/utils/locale";
@@ -15,23 +9,14 @@ export default async function AdminUsersPage() {
 
   return (
     <div>
-      <div className="flex justify-center mb-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home/admin">Administration</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <span>{dictionary.users}</span>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </div>
+      <PageBreadcrumb
+        pathname="/home/admin/users"
+        dictionary={dictionary.breadcrumb}
+        siblings={[
+          { label: dictionary.breadcrumb.users, href: "/home/admin/users" },
+          { label: dictionary.breadcrumb.roles, href: "/home/admin/roles" },
+        ]}
+      />
       <UsersV2 dictionary={dictionary.admin_users} />
     </div>
   );

--- a/app/home/projects/page.tsx
+++ b/app/home/projects/page.tsx
@@ -1,27 +1,17 @@
-import {
-  Breadcrumb,
-  BreadcrumbList,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import { getDictionary } from "@/lib/utils/dictionaries";
+import { getUserLanguage } from "@/lib/utils/locale";
+import PageBreadcrumb from "@/components/shared/PageBreadcrumb";
 
-export default function ProjectsPage() {
+export default async function ProjectsPage() {
+  const userLanguage = await getUserLanguage();
+  const dictionary = await getDictionary(userLanguage);
+
   return (
     <main>
-      <div className="flex justify-center mb-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <span>Projets</span>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </div>
+      <PageBreadcrumb
+        pathname="/home/projects"
+        dictionary={dictionary.breadcrumb}
+      />
       {/* Page projets vide */}
     </main>
   );

--- a/app/home/settings/company/page.tsx
+++ b/app/home/settings/company/page.tsx
@@ -9,13 +9,7 @@
  * For commercial licensing inquiries, contact: benjamin@waterfall-project.pro
  */
 
-import {
-  Breadcrumb,
-  BreadcrumbList,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import PageBreadcrumb from "@/components/shared/PageBreadcrumb";
 import Company from "@/components/pages/Company";
 import { getDictionary } from "@/lib/utils/dictionaries";
 import { getLocale } from "@/lib/utils/locale";
@@ -38,23 +32,16 @@ export default async function CompanyInfoPage() {
 
   return (
     <main>
-      <div className="flex justify-center mb-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home/settings">Paramètres</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <span>Informations de l&apos;entreprise</span>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </div>
+      <PageBreadcrumb
+        pathname="/home/settings/company"
+        dictionary={dict.breadcrumb}
+        siblings={[
+          { label: dict.breadcrumb.company, href: "/home/settings/company" },
+          { label: dict.breadcrumb.customers, href: "/home/settings/customers" },
+          { label: dict.breadcrumb.subcontractors, href: "/home/settings/subcontractors" },
+          { label: dict.breadcrumb.organization, href: "/home/settings/organization" },
+        ]}
+      />
       <div className="max-w-4xl mx-auto">
         <Company companyId={companyId} dictionary={dict.company} />
       </div>

--- a/app/home/settings/customers/page.tsx
+++ b/app/home/settings/customers/page.tsx
@@ -9,13 +9,7 @@
  * For commercial licensing inquiries, contact: benjamin@waterfall-project.pro
  */
 
-import {
-  Breadcrumb,
-  BreadcrumbList,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import PageBreadcrumb from "@/components/shared/PageBreadcrumb";
 import Customers from "@/components/pages/Customers";
 import { getDictionary } from "@/lib/utils/dictionaries";
 import { getLocale } from "@/lib/utils/locale";
@@ -26,23 +20,16 @@ export default async function CustomersPage() {
 
   return (
     <main>
-      <div className="flex justify-center mb-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home/settings">Paramètres</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <span>Clients</span>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </div>
+      <PageBreadcrumb
+        pathname="/home/settings/customers"
+        dictionary={dict.breadcrumb}
+        siblings={[
+          { label: dict.breadcrumb.company, href: "/home/settings/company" },
+          { label: dict.breadcrumb.customers, href: "/home/settings/customers" },
+          { label: dict.breadcrumb.subcontractors, href: "/home/settings/subcontractors" },
+          { label: dict.breadcrumb.organization, href: "/home/settings/organization" },
+        ]}
+      />
       <div className="max-w-6xl mx-auto">
         <Customers 
           dictionary={dict.customers} 

--- a/app/home/settings/organization/page.tsx
+++ b/app/home/settings/organization/page.tsx
@@ -9,13 +9,7 @@
  * For commercial licensing inquiries, contact: benjamin@waterfall-project.pro
  */
 
-import {
-  Breadcrumb,
-  BreadcrumbList,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import PageBreadcrumb from "@/components/shared/PageBreadcrumb";
 import OrganizationTree from "@/components/pages/OrganizationTree";
 import { getDictionary } from "@/lib/utils/dictionaries";
 import { getLocale } from "@/lib/utils/locale";
@@ -38,23 +32,16 @@ export default async function OrganizationPage() {
 
   return (
     <main>
-      <div className="flex justify-center mb-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home/settings">Paramètres</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <span>Structure organisationnelle</span>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </div>
+      <PageBreadcrumb
+        pathname="/home/settings/organization"
+        dictionary={dict.breadcrumb}
+        siblings={[
+          { label: dict.breadcrumb.company, href: "/home/settings/company" },
+          { label: dict.breadcrumb.customers, href: "/home/settings/customers" },
+          { label: dict.breadcrumb.subcontractors, href: "/home/settings/subcontractors" },
+          { label: dict.breadcrumb.organization, href: "/home/settings/organization" },
+        ]}
+      />
       <div className="max-w-6xl mx-auto">
         <OrganizationTree companyId={companyId} dictionary={dict.organization} />
       </div>

--- a/app/home/settings/page.tsx
+++ b/app/home/settings/page.tsx
@@ -9,31 +9,21 @@
  * For commercial licensing inquiries, contact: benjamin@waterfall-project.pro
  */
 
-import {
-  Breadcrumb,
-  BreadcrumbList,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import PageBreadcrumb from "@/components/shared/PageBreadcrumb";
 import SettingsCards from "@/components/cards/SettingsCards";
+import { getDictionary } from "@/lib/utils/dictionaries";
+import { getUserLanguage } from "@/lib/utils/locale";
 
 export default async function SettingsPage() {
+  const userLanguage = await getUserLanguage();
+  const dictionary = await getDictionary(userLanguage);
+
   return (
     <main>
-      <div className="flex justify-center mb-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <span>Paramètres</span>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </div>
+      <PageBreadcrumb
+        pathname="/home/settings"
+        dictionary={dictionary.breadcrumb}
+      />
       <SettingsCards dictionary={{}} />
     </main>
   );

--- a/app/home/settings/subcontractors/page.tsx
+++ b/app/home/settings/subcontractors/page.tsx
@@ -9,13 +9,7 @@
  * For commercial licensing inquiries, contact: benjamin@waterfall-project.pro
  */
 
-import {
-  Breadcrumb,
-  BreadcrumbList,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
+import PageBreadcrumb from "@/components/shared/PageBreadcrumb";
 import Subcontractors from "@/components/pages/Subcontractors";
 import { getDictionary } from "@/lib/utils/dictionaries";
 import { getLocale } from "@/lib/utils/locale";
@@ -26,23 +20,16 @@ export default async function SubcontractorsPage() {
   
   return (
     <main>
-      <div className="flex justify-center mb-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/home/settings">Paramètres</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <span>Sous-traitants</span>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-      </div>
+      <PageBreadcrumb
+        pathname="/home/settings/subcontractors"
+        dictionary={dict.breadcrumb}
+        siblings={[
+          { label: dict.breadcrumb.company, href: "/home/settings/company" },
+          { label: dict.breadcrumb.customers, href: "/home/settings/customers" },
+          { label: dict.breadcrumb.subcontractors, href: "/home/settings/subcontractors" },
+          { label: dict.breadcrumb.organization, href: "/home/settings/organization" },
+        ]}
+      />
       <div className="max-w-6xl mx-auto">
         <Subcontractors 
           dictionary={dict.subcontractors} 

--- a/app/home/workspace/page.tsx
+++ b/app/home/workspace/page.tsx
@@ -11,13 +11,20 @@
 
 import { FileExplorer } from "@/components/shared/FileExplorer";
 import { getDictionary } from "@/lib/utils/dictionaries";
+import { getUserLanguage } from "@/lib/utils/locale";
+import PageBreadcrumb from "@/components/shared/PageBreadcrumb";
 
 export default async function WorkspacePage() {
-  const dict = await getDictionary("fr");
+  const userLanguage = await getUserLanguage();
+  const dict = await getDictionary(userLanguage);
   const { errors, ...workspaceDict } = dict.workspace;
 
   return (
     <div className="container mx-auto p-6">
+      <PageBreadcrumb
+        pathname="/home/workspace"
+        dictionary={dict.breadcrumb}
+      />
       <div className="mb-6">
         <h1 className="text-3xl font-bold">{dict.workspace.workspace}</h1>
         <p className="text-muted-foreground mt-2">{dict.workspace.workspace_description}</p>

--- a/components/shared/PageBreadcrumb.test.tsx
+++ b/components/shared/PageBreadcrumb.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * Copyright (c) 2025 Waterfall
+ * 
+ * This source code is dual-licensed under:
+ * - GNU Affero General Public License v3.0 (AGPLv3) for open source use
+ * - Commercial License for proprietary use
+ * 
+ * See LICENSE and LICENSE.md files in the root directory for full license text.
+ * For commercial licensing inquiries, contact: benjamin@waterfall-project.pro
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import PageBreadcrumb from './PageBreadcrumb';
+import { PAGE_BREADCRUMB_TEST_IDS } from '@/lib/test-ids';
+
+// Mock next/navigation
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+describe('PageBreadcrumb', () => {
+  const mockDictionary = {
+    home: 'Home',
+    admin: 'Administration',
+    users: 'Users',
+    roles: 'Roles',
+    settings: 'Settings',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Basic Rendering', () => {
+    it('should render breadcrumb container', () => {
+      render(
+        <PageBreadcrumb pathname="/home" dictionary={mockDictionary} />
+      );
+
+      expect(screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.container)).toBeInTheDocument();
+      expect(screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.list)).toBeInTheDocument();
+    });
+
+    it('should render single level breadcrumb', () => {
+      render(
+        <PageBreadcrumb pathname="/home" dictionary={mockDictionary} />
+      );
+
+      expect(screen.getByText('Home')).toBeInTheDocument();
+      expect(screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.currentItem)).toHaveTextContent('Home');
+    });
+
+    it('should render two level breadcrumb with separator', () => {
+      render(
+        <PageBreadcrumb pathname="/home/admin" dictionary={mockDictionary} />
+      );
+
+      expect(screen.getByText('Home')).toBeInTheDocument();
+      expect(screen.getByText('Administration')).toBeInTheDocument();
+      expect(screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.separator)).toBeInTheDocument();
+    });
+
+    it('should render multi-level breadcrumb', () => {
+      render(
+        <PageBreadcrumb pathname="/home/admin/users" dictionary={mockDictionary} />
+      );
+
+      expect(screen.getByText('Home')).toBeInTheDocument();
+      expect(screen.getByText('Administration')).toBeInTheDocument();
+      expect(screen.getByText('Users')).toBeInTheDocument();
+
+      // Should have 2 separators for 3 items
+      const separators = screen.getAllByTestId(PAGE_BREADCRUMB_TEST_IDS.separator);
+      expect(separators).toHaveLength(2);
+    });
+  });
+
+  describe('Navigation', () => {
+    it('should render links for all items except the last', () => {
+      render(
+        <PageBreadcrumb pathname="/home/admin/users" dictionary={mockDictionary} />
+      );
+
+      // First two items should be links
+      const homeLink = screen.getByTestId(`${PAGE_BREADCRUMB_TEST_IDS.link}-home`);
+      const adminLink = screen.getByTestId(`${PAGE_BREADCRUMB_TEST_IDS.link}-admin`);
+
+      expect(homeLink).toHaveAttribute('href', '/home');
+      expect(adminLink).toHaveAttribute('href', '/home/admin');
+
+      // Last item should be plain text (current page)
+      expect(screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.currentItem)).toHaveTextContent('Users');
+    });
+
+    it('should build correct paths for nested routes', () => {
+      render(
+        <PageBreadcrumb
+          pathname="/home/settings/company"
+          dictionary={mockDictionary}
+        />
+      );
+
+      expect(screen.getByTestId(`${PAGE_BREADCRUMB_TEST_IDS.link}-home`)).toHaveAttribute('href', '/home');
+      expect(screen.getByTestId(`${PAGE_BREADCRUMB_TEST_IDS.link}-settings`)).toHaveAttribute('href', '/home/settings');
+    });
+  });
+
+  describe('Internationalization', () => {
+    it('should use dictionary labels', () => {
+      const frenchDictionary = {
+        home: 'Accueil',
+        admin: 'Administration',
+        users: 'Utilisateurs',
+      };
+
+      render(
+        <PageBreadcrumb pathname="/home/admin/users" dictionary={frenchDictionary} />
+      );
+
+      expect(screen.getByText('Accueil')).toBeInTheDocument();
+      expect(screen.getByText('Administration')).toBeInTheDocument();
+      expect(screen.getByText('Utilisateurs')).toBeInTheDocument();
+    });
+
+    it('should fallback to segment name if not in dictionary', () => {
+      render(
+        <PageBreadcrumb
+          pathname="/home/unknown-page"
+          dictionary={mockDictionary}
+        />
+      );
+
+      expect(screen.getByText('Home')).toBeInTheDocument();
+      expect(screen.getByText('unknown-page')).toBeInTheDocument();
+    });
+  });
+
+  describe('Siblings Dropdown', () => {
+    const siblings = [
+      { label: 'Users', href: '/home/admin/users' },
+      { label: 'Roles', href: '/home/admin/roles' },
+    ];
+
+    it('should render dropdown trigger when siblings provided', () => {
+      render(
+        <PageBreadcrumb
+          pathname="/home/admin/users"
+          dictionary={mockDictionary}
+          siblings={siblings}
+        />
+      );
+
+      expect(screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.dropdownTrigger)).toBeInTheDocument();
+      expect(screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.currentItem)).toHaveTextContent('Users');
+    });
+
+    it('should show dropdown menu on click', async () => {
+      const user = userEvent.setup();
+      render(
+        <PageBreadcrumb
+          pathname="/home/admin/users"
+          dictionary={mockDictionary}
+          siblings={siblings}
+        />
+      );
+
+      const trigger = screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.dropdownTrigger);
+      await user.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.dropdownContent)).toBeVisible();
+      });
+    });
+
+    it('should render all sibling items in dropdown', async () => {
+      const user = userEvent.setup();
+      render(
+        <PageBreadcrumb
+          pathname="/home/admin/users"
+          dictionary={mockDictionary}
+          siblings={siblings}
+        />
+      );
+
+      const trigger = screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.dropdownTrigger);
+      await user.click(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(`${PAGE_BREADCRUMB_TEST_IDS.dropdownItem}-users`)).toBeVisible();
+        expect(screen.getByTestId(`${PAGE_BREADCRUMB_TEST_IDS.dropdownItem}-roles`)).toBeVisible();
+      });
+    });
+
+    it('should navigate to sibling on click', async () => {
+      const user = userEvent.setup();
+      render(
+        <PageBreadcrumb
+          pathname="/home/admin/users"
+          dictionary={mockDictionary}
+          siblings={siblings}
+        />
+      );
+
+      const trigger = screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.dropdownTrigger);
+      await user.click(trigger);
+
+      await waitFor(async () => {
+        const rolesItem = screen.getByTestId(`${PAGE_BREADCRUMB_TEST_IDS.dropdownItem}-roles`);
+        await user.click(rolesItem);
+        expect(mockPush).toHaveBeenCalledWith('/home/admin/roles');
+      });
+    });
+
+    it('should not render dropdown without siblings', () => {
+      render(
+        <PageBreadcrumb pathname="/home/admin/users" dictionary={mockDictionary} />
+      );
+
+      expect(screen.queryByTestId(PAGE_BREADCRUMB_TEST_IDS.dropdownTrigger)).not.toBeInTheDocument();
+      expect(screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.currentItem)).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle root path', () => {
+      render(
+        <PageBreadcrumb pathname="/" dictionary={mockDictionary} />
+      );
+
+      // Root path results in empty breadcrumb (no segments after split/filter)
+      expect(screen.getByTestId(PAGE_BREADCRUMB_TEST_IDS.container)).toBeInTheDocument();
+    });
+
+    it('should handle trailing slash', () => {
+      render(
+        <PageBreadcrumb pathname="/home/admin/" dictionary={mockDictionary} />
+      );
+
+      // Should work the same as without trailing slash
+      expect(screen.getByText('Home')).toBeInTheDocument();
+      expect(screen.getByText('Administration')).toBeInTheDocument();
+    });
+
+    it('should handle empty siblings array', () => {
+      render(
+        <PageBreadcrumb
+          pathname="/home/admin"
+          dictionary={mockDictionary}
+          siblings={[]}
+        />
+      );
+
+      // Empty array should not show dropdown
+      expect(screen.queryByTestId(PAGE_BREADCRUMB_TEST_IDS.dropdownTrigger)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have test-ids for all items', () => {
+      render(
+        <PageBreadcrumb pathname="/home/admin/users" dictionary={mockDictionary} />
+      );
+
+      expect(screen.getByTestId(`${PAGE_BREADCRUMB_TEST_IDS.item}-home`)).toBeInTheDocument();
+      expect(screen.getByTestId(`${PAGE_BREADCRUMB_TEST_IDS.item}-admin`)).toBeInTheDocument();
+      expect(screen.getByTestId(`${PAGE_BREADCRUMB_TEST_IDS.item}-users`)).toBeInTheDocument();
+    });
+
+    it('should have accessible links', () => {
+      render(
+        <PageBreadcrumb pathname="/home/admin" dictionary={mockDictionary} />
+      );
+
+      const homeLink = screen.getByTestId(`${PAGE_BREADCRUMB_TEST_IDS.link}-home`);
+      expect(homeLink).toHaveAttribute('href', '/home');
+      expect(homeLink).toHaveTextContent('Home');
+    });
+  });
+});

--- a/components/shared/PageBreadcrumb.tsx
+++ b/components/shared/PageBreadcrumb.tsx
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2025 Waterfall
+ * 
+ * This source code is dual-licensed under:
+ * - GNU Affero General Public License v3.0 (AGPLv3) for open source use
+ * - Commercial License for proprietary use
+ * 
+ * See LICENSE and LICENSE.md files in the root directory for full license text.
+ * For commercial licensing inquiries, contact: benjamin@waterfall-project.pro
+ */
+
+"use client";
+
+import React from "react";
+import { ChevronDown } from "lucide-react";
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { PAGE_BREADCRUMB_TEST_IDS, testId } from "@/lib/test-ids";
+import { ICON_SIZES } from "@/lib/design-tokens";
+import { useRouter } from "next/navigation";
+
+export type BreadcrumbSibling = {
+  label: string;
+  href: string;
+};
+
+export type PageBreadcrumbProps = {
+  /**
+   * Current pathname (e.g., "/home/admin/users")
+   */
+  pathname: string;
+
+  /**
+   * Breadcrumb dictionary with path segment translations
+   * e.g., { home: "Home", admin: "Administration", users: "Users" }
+   */
+  dictionary: Record<string, string>;
+
+  /**
+   * Optional siblings for dropdown menu on current page
+   * e.g., [{ label: "Users", href: "/home/admin/users" }, { label: "Roles", href: "/home/admin/roles" }]
+   */
+  siblings?: BreadcrumbSibling[];
+};
+
+/**
+ * PageBreadcrumb - Breadcrumb navigation component
+ *
+ * Features:
+ * - Auto-generates breadcrumb from pathname
+ * - Internationalization support via dictionary
+ * - Optional dropdown menu for sibling pages
+ * - Full accessibility and test-id support
+ *
+ * @example
+ * ```tsx
+ * <PageBreadcrumb
+ *   pathname="/home/admin/users"
+ *   dictionary={dictionary.breadcrumb}
+ *   siblings={[
+ *     { label: "Users", href: "/home/admin/users" },
+ *     { label: "Roles", href: "/home/admin/roles" }
+ *   ]}
+ * />
+ * ```
+ */
+export default function PageBreadcrumb({
+  pathname,
+  dictionary,
+  siblings,
+}: PageBreadcrumbProps) {
+  const router = useRouter();
+
+  // Parse pathname into breadcrumb items
+  const segments = pathname.split('/').filter(Boolean);
+  const items = segments.map((segment, index) => {
+    const path = `/${segments.slice(0, index + 1).join('/')}`;
+    const label = dictionary[segment] || segment;
+    const isLast = index === segments.length - 1;
+
+    return {
+      segment,
+      label,
+      href: path,
+      isLast,
+    };
+  });
+
+  const handleSiblingClick = (href: string) => {
+    router.push(href);
+  };
+
+  return (
+    <div className="flex justify-center mb-4" {...testId(PAGE_BREADCRUMB_TEST_IDS.container)}>
+      <Breadcrumb>
+        <BreadcrumbList {...testId(PAGE_BREADCRUMB_TEST_IDS.list)}>
+          {items.map((item) => (
+            <React.Fragment key={item.segment}>
+              <BreadcrumbItem {...testId(`${PAGE_BREADCRUMB_TEST_IDS.item}-${item.segment}`)}>
+                {item.isLast ? (
+                  siblings && siblings.length > 0 ? (
+                    // Last item with siblings - show dropdown
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        className="flex items-center gap-1"
+                        {...testId(PAGE_BREADCRUMB_TEST_IDS.dropdownTrigger)}
+                      >
+                        <span {...testId(PAGE_BREADCRUMB_TEST_IDS.currentItem)}>
+                          {item.label}
+                        </span>
+                        <ChevronDown className={ICON_SIZES.xs} />
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent
+                        align="start"
+                        {...testId(PAGE_BREADCRUMB_TEST_IDS.dropdownContent)}
+                      >
+                        {siblings.map((sibling) => (
+                          <DropdownMenuItem
+                            key={sibling.href}
+                            onClick={() => handleSiblingClick(sibling.href)}
+                            {...testId(`${PAGE_BREADCRUMB_TEST_IDS.dropdownItem}-${sibling.href.split('/').pop()}`)}
+                          >
+                            {sibling.label}
+                          </DropdownMenuItem>
+                        ))}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  ) : (
+                    // Last item without siblings - plain text
+                    <span {...testId(PAGE_BREADCRUMB_TEST_IDS.currentItem)}>
+                      {item.label}
+                    </span>
+                  )
+                ) : (
+                  // Not last item - link
+                  <BreadcrumbLink
+                    href={item.href}
+                    {...testId(`${PAGE_BREADCRUMB_TEST_IDS.link}-${item.segment}`)}
+                  >
+                    {item.label}
+                  </BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+
+              {!item.isLast && (
+                <BreadcrumbSeparator {...testId(PAGE_BREADCRUMB_TEST_IDS.separator)} />
+              )}
+            </React.Fragment>
+          ))}
+        </BreadcrumbList>
+      </Breadcrumb>
+    </div>
+  );
+}

--- a/dictionaries/en/breadcrumb.json
+++ b/dictionaries/en/breadcrumb.json
@@ -1,0 +1,13 @@
+{
+  "home": "Home",
+  "admin": "Administration",
+  "users": "Users",
+  "roles": "Roles",
+  "settings": "Settings",
+  "company": "Company",
+  "organization": "Organization",
+  "customers": "Customers",
+  "subcontractors": "Subcontractors",
+  "projects": "Projects",
+  "workspace": "Workspace"
+}

--- a/dictionaries/fr/breadcrumb.json
+++ b/dictionaries/fr/breadcrumb.json
@@ -1,0 +1,13 @@
+{
+  "home": "Accueil",
+  "admin": "Administration",
+  "users": "Utilisateurs",
+  "roles": "Rôles",
+  "settings": "Paramètres",
+  "company": "Entreprise",
+  "organization": "Organisation",
+  "customers": "Clients",
+  "subcontractors": "Sous-traitants",
+  "projects": "Projets",
+  "workspace": "Espace de travail"
+}

--- a/lib/test-ids/index.ts
+++ b/lib/test-ids/index.ts
@@ -28,6 +28,7 @@ export * from './settings';
 export * from './file-explorer';
 export * from './organization-tree';
 export * from './profile';
+export * from './page-breadcrumb';
 
 // Re-export helper function
 export { testId } from './auth';
@@ -47,6 +48,7 @@ import { SETTINGS_TEST_IDS } from './settings';
 import { FILE_EXPLORER_TEST_IDS } from './file-explorer';
 import { ORGANIZATION_TREE_TEST_IDS } from './organization-tree';
 import { PROFILE_TEST_IDS } from './profile';
+import { PAGE_BREADCRUMB_TEST_IDS } from './page-breadcrumb';
 
 export const TEST_IDS = {
   auth: AUTH_TEST_IDS,
@@ -63,4 +65,5 @@ export const TEST_IDS = {
   fileExplorer: FILE_EXPLORER_TEST_IDS,
   organizationTree: ORGANIZATION_TREE_TEST_IDS,
   profile: PROFILE_TEST_IDS,
+  pageBreadcrumb: PAGE_BREADCRUMB_TEST_IDS,
 } as const;

--- a/lib/test-ids/page-breadcrumb.ts
+++ b/lib/test-ids/page-breadcrumb.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2025 Waterfall
+ * 
+ * This source code is dual-licensed under:
+ * - GNU Affero General Public License v3.0 (AGPLv3) for open source use
+ * - Commercial License for proprietary use
+ * 
+ * See LICENSE and LICENSE.md files in the root directory for full license text.
+ * For commercial licensing inquiries, contact: benjamin@waterfall-project.pro
+ */
+
+/**
+ * Test IDs for PageBreadcrumb component
+ */
+export const PAGE_BREADCRUMB_TEST_IDS = {
+  container: 'page-breadcrumb-container',
+  list: 'page-breadcrumb-list',
+  item: 'page-breadcrumb-item',
+  link: 'page-breadcrumb-link',
+  separator: 'page-breadcrumb-separator',
+  currentItem: 'page-breadcrumb-current',
+  dropdown: 'page-breadcrumb-dropdown',
+  dropdownTrigger: 'page-breadcrumb-dropdown-trigger',
+  dropdownContent: 'page-breadcrumb-dropdown-content',
+  dropdownItem: 'page-breadcrumb-dropdown-item',
+} as const;

--- a/lib/utils/dictionaries.ts
+++ b/lib/utils/dictionaries.ts
@@ -61,6 +61,7 @@ import subcontractors_fr from '../../dictionaries/fr/subcontractors.json';
 import customers_fr from '../../dictionaries/fr/customers.json';
 import logoUpload_fr from '../../dictionaries/fr/logo-upload.json';
 import about_fr from '../../dictionaries/fr/about.json';
+import breadcrumb_fr from '../../dictionaries/fr/breadcrumb.json';
 
 import common_en from '../../dictionaries/en/common.json';
 import navigation_en from '../../dictionaries/en/navigation.json';
@@ -81,6 +82,7 @@ import subcontractors_en from '../../dictionaries/en/subcontractors.json';
 import customers_en from '../../dictionaries/en/customers.json';
 import logoUpload_en from '../../dictionaries/en/logo-upload.json';
 import about_en from '../../dictionaries/en/about.json';
+import breadcrumb_en from '../../dictionaries/en/breadcrumb.json';
 
 export type Locale = 'fr' | 'en';
 
@@ -106,6 +108,7 @@ const dictionaries = {
     customers: customers_fr,
     logo_upload: logoUpload_fr,
     about: about_fr,
+    breadcrumb: breadcrumb_fr,
   },
   en: {
     ...common_en,
@@ -127,6 +130,7 @@ const dictionaries = {
     customers: customers_en,
     logo_upload: logoUpload_en,
     about: about_en,
+    breadcrumb: breadcrumb_en,
   },
 } as const;
 


### PR DESCRIPTION
## Description

Ce PR ajoute un nouveau composant **PageBreadcrumb** qui standardise l'affichage du fil d'Ariane sur toutes les pages avec support i18n et navigation entre pages sœurs.

## Fonctionnalités

✅ **Génération automatique** : Le breadcrumb se génère automatiquement à partir du pathname
✅ **Support i18n** : Traductions en/fr via dictionnaires avec fallback si traduction manquante
✅ **Menu déroulant siblings** : Navigation entre pages du même niveau (ex: Users ↔ Roles)
✅ **Niveaux illimités** : Support de n'importe quelle profondeur de navigation
✅ **Standards DEVELOPER_GUIDE** : Test-ids, design tokens, structure conforme
✅ **Tests complets** : 18 tests couvrant tous les cas d'usage

## Changements

### Nouveaux fichiers
- `components/shared/PageBreadcrumb.tsx` - Composant principal
- `components/shared/PageBreadcrumb.test.tsx` - Tests (18/18 passing)
- `lib/test-ids/page-breadcrumb.ts` - Test IDs (10 identifiants)
- `dictionaries/en/breadcrumb.json` - Traductions anglaises
- `dictionaries/fr/breadcrumb.json` - Traductions françaises

### Pages modifiées (10)
- `app/home/admin/page.tsx`
- `app/home/admin/users/page.tsx` (avec siblings dropdown)
- `app/home/admin/roles/page.tsx` (avec siblings dropdown)
- `app/home/projects/page.tsx`
- `app/home/settings/page.tsx`
- `app/home/settings/company/page.tsx` (avec siblings dropdown)
- `app/home/settings/customers/page.tsx` (avec siblings dropdown)
- `app/home/settings/subcontractors/page.tsx` (avec siblings dropdown)
- `app/home/settings/organization/page.tsx` (avec siblings dropdown)
- `app/home/workspace/page.tsx`

### Utilitaires
- `lib/utils/dictionaries.ts` - Ajout du chargement breadcrumb
- `lib/test-ids/index.ts` - Export des nouveaux test-ids

## Tests

✅ Build : Passing
✅ Lint : Passing  
✅ Tests : 682 passing (18 nouveaux pour PageBreadcrumb)

## Checklist

- [x] Code suit DEVELOPER_GUIDE
- [x] Tests ajoutés et passants
- [x] i18n supporté (en/fr)
- [x] Test-ids ajoutés
- [x] Design tokens utilisés
- [x] Build et lint passent
- [x] Documentation inline (JSDoc)
